### PR TITLE
CustomerSupport Chatbot — UI Cleanup, Feature Flags & Agent Prompt Updates

### DIFF
--- a/daxa_chatbot_app/.env.example
+++ b/daxa_chatbot_app/.env.example
@@ -32,6 +32,9 @@ ATLASSIAN_DOCKER_API_KEY=
 DIRECT_ATLASSIAN_MCP_URL=
 DIRECT_CUSTOMER_BILLING_MCP_URL=
 
+# JIRA Tickets List
+JIRA_TICKETS=KAN-19,KAN-22,KAN-25,KAN-46,KAN-47
+
 # ── OAuth redirect URIs (must match the Streamlit app URL + page path) ──────
 # Main app  →  http://localhost:8501
 # Test page →  http://localhost:8501/test

--- a/daxa_chatbot_app/README.md
+++ b/daxa_chatbot_app/README.md
@@ -239,6 +239,7 @@ SHOW_SAFE_INFER=True        # Show/hide the Safe Infer tab (default: True)
 SHOW_INSECURE_INFER=True    # Show/hide the Insecure Inference tab (default: True)
 SHOW_SAFE_AGENT=True        # Show/hide the Safe Agent tab (default: True)
 SHOW_INSECURE_AGENT=True    # Show/hide the Insecure Agent tab (default: True)
+JIRA_TICKETS=KAN-19,KAN-22 # Comma-separated ticket IDs shown in agent sidebars above Recent Tickets (optional)
 ATLASSIAN_OAUTH=True        # Atlassian with OAuth — shows URL + Pebblo key (Safe Agent) or URL only (InSecure Agent) + Connect button
 ATLASSIAN_DOCKER=True       # Atlassian without OAuth — shows URL + Pebblo key (Safe) or URL only (InSecure)
 CUSTOMER_BILLING=True       # Customer Billing — shows URL + Pebblo key (Safe) or URL only (InSecure)

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -487,11 +487,11 @@ with st.sidebar:
 
         st.markdown("---")
         if _TICKET_LIST:
-            st.subheader("🎫 Tickets")
+            st.subheader("🎫 Recent Tickets")
             for _tid in _TICKET_LIST:
                 st.markdown(f"- `{_tid}`")
             st.markdown("---")
-        st.subheader("📝 Recent Tickets")
+        st.subheader("📝 Suggested Queries")
         _INSECURE_AGENT_PROMPTS = [
             ("Threat Protection",                   "Tell me details about KAN-19"),
             ("Data Privacy: Topics (Custom)",       "Tell me details about KAN-47."),
@@ -588,11 +588,11 @@ with st.sidebar:
 
         st.markdown("---")
         if _TICKET_LIST:
-            st.subheader("🎫 Tickets")
+            st.subheader("🎫 Recent Tickets")
             for _tid in _TICKET_LIST:
                 st.markdown(f"- `{_tid}`")
             st.markdown("---")
-        st.subheader("📝 Recent Tickets")
+        st.subheader("📝 Suggested Queries")
         _AGENT_PROMPTS = [
             ("Threat Protection",                   "Tell me details about KAN-19"),
             ("Data Privacy: Topics (Custom)",       "Tell me details about KAN-47."),

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -261,6 +261,9 @@ SHOW_INSECURE_INFER  = os.getenv("SHOW_INSECURE_INFER",  "true").strip().lower()
 SHOW_SAFE_AGENT      = os.getenv("SHOW_SAFE_AGENT",      "true").strip().lower() == "true"
 SHOW_INSECURE_AGENT  = os.getenv("SHOW_INSECURE_AGENT",  "true").strip().lower() == "true"
 
+# Comma-separated ticket IDs to display in agent sidebars, e.g. "KAN-19,KAN-22,KAN-46"
+_TICKET_LIST = [t.strip() for t in os.getenv("JIRA_TICKETS", "").split(",") if t.strip()]
+
 _MODE_LABELS = {
     "Safe Infer":     "🟢 Safe Infer",
     "InSecure Infer": "🔴 Insecure Inference",
@@ -269,13 +272,13 @@ _MODE_LABELS = {
 }
 _LABEL_TO_MODE = {v: k for k, v in _MODE_LABELS.items()}
 
-# Display order: row1 = [Safe Infer, Insecure Inference], row2 = [Safe Agent, Insecure Agent]
+# Display order: row1 = [Safe Infer, Insecure Inference], row2 = [Insecure Agent, Safe Agent]
 # Each entry is only included when its feature flag is enabled.
 _MODE_OPTIONS = [
     *(["🟢 Safe Infer"]          if SHOW_SAFE_INFER      else []),
     *(["🔴 Insecure Inference"]  if SHOW_INSECURE_INFER  else []),
-    *(["🟢 Safe Agent"]          if SHOW_SAFE_AGENT       else []),
     *(["🔴 Insecure Agent"]      if SHOW_INSECURE_AGENT   else []),
+    *(["🟢 Safe Agent"]          if SHOW_SAFE_AGENT       else []),
 ]
 
 # Default to the first available option
@@ -483,6 +486,11 @@ with st.sidebar:
             )
 
         st.markdown("---")
+        if _TICKET_LIST:
+            st.subheader("🎫 Tickets")
+            for _tid in _TICKET_LIST:
+                st.markdown(f"- `{_tid}`")
+            st.markdown("---")
         st.subheader("📝 Recent Tickets")
         _INSECURE_AGENT_PROMPTS = [
             ("Threat Protection",                   "Tell me details about KAN-19"),
@@ -579,6 +587,11 @@ with st.sidebar:
         )
 
         st.markdown("---")
+        if _TICKET_LIST:
+            st.subheader("🎫 Tickets")
+            for _tid in _TICKET_LIST:
+                st.markdown(f"- `{_tid}`")
+            st.markdown("---")
         st.subheader("📝 Recent Tickets")
         _AGENT_PROMPTS = [
             ("Threat Protection",                   "Tell me details about KAN-19"),


### PR DESCRIPTION

<h4>Summary</h4>
<ul>
<li>
<p><strong>Remove subtitle</strong> from main header</p>
</li>
<li>
<p><strong>Remove subheaders/captions</strong> from all four mode main areas (Safe Infer, Insecure Inference, Safe Agent, Insecure Agent)</p>
</li>
<li>
<p><strong>Feature-flag all four mode tabs</strong> — each tab independently controlled via env var; mode list and default selection built dynamically:</p>

Env Var | Default | Controls
-- | -- | --
SHOW_SAFE_INFER | True | 🟢 Safe Infer tab
SHOW_INSECURE_INFER | True | 🔴 Insecure Inference tab
SHOW_INSECURE_AGENT | True | 🔴 Insecure Agent tab
SHOW_SAFE_AGENT | True | 🟢 Safe Agent tab


<hr>
<h4>Test Plan</h4>
<ul>
<li>[ ] Set any mode flag to <code>False</code> → that tab disappears; default lands on first available</li>
<li>[ ] Set all agent flags to <code>False</code>, infer flags to <code>True</code> → only infer tabs shown</li>
<li>[ ] Set <code>JIRA_TICKETS=KAN-19,KAN-22</code> → 🎫 Tickets section appears above Recent Tickets in both agent sidebars</li>
<li>[ ] Leave <code>JIRA_TICKETS</code> unset → 🎫 Tickets section hidden</li>
<li>[ ] All 5 Recent Tickets prompts populate the query box on <code>→</code> click in both Safe Agent and Insecure Agent</li>
<li>[ ] Safe Agent: enter user/group in sidebar → logs show correct <code>x-pebblo-users</code> / <code>x-pebblo-user-groups</code> values</li>
<li>[ ] Safe Agent: leave user/group blank → logs fall back to env <code>X_PEBBLO_USER</code> / <code>X_PEBBLO_USER_GROUPS</code></li>
<li>[ ] Row 2 tab order is <code>Insecure Agent | Safe Agent</code></li>
<li>[ ] No subheader/caption visible above chat inputs in any mode</li>
</ul></body></html>