### PR TITLE
Add MCP pipeline routing behind feature flags for Infer modes

### DIFF
--- a/daxa_chatbot_app/.env.example
+++ b/daxa_chatbot_app/.env.example
@@ -11,6 +11,9 @@ OPENAI_API_KEY=
 # ── MCP Server URLs  ─────────────────────────────────────────────────────────
 
 # ── Feature flags (True = show that server in the sidebar) ───────────────────
+USE_PROXIMA_FOR_INSECURE_AGENT=
+SAFE_INFER_CONTEXT=
+INSECURE_INFER_CONTEXT=
 SHOW_SAFE_INFER=
 SHOW_INSECURE_INFER=
 SHOW_SAFE_INFER=

--- a/daxa_chatbot_app/.env.example
+++ b/daxa_chatbot_app/.env.example
@@ -5,6 +5,8 @@ USER_EMAIL=
 USER_TEAM=
 X_PEBBLO_USER=
 X_PEBBLO_USER_GROUPS=
+# Comma-separated list of users shown in the sidebar selector
+PEBBLO_USERS=
 MODEL=
 OPENAI_API_KEY=
 

--- a/daxa_chatbot_app/mcp_utils.py
+++ b/daxa_chatbot_app/mcp_utils.py
@@ -21,6 +21,9 @@ load_dotenv(_env_path)
 from utils import API_BASE_URL, API_KEY, MODEL, X_PEBBLO_USER, X_PEBBLO_USER_GROUPS
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
+USE_PROXIMA_FOR_INSECURE_AGENT = os.getenv("USE_PROXIMA_FOR_INSECURE_AGENT", "false").strip().lower() == "true"
+SAFE_INFER_CONTEXT = os.getenv("SAFE_INFER_CONTEXT", "false").strip().lower() == "true"
+INSECURE_INFER_CONTEXT = os.getenv("INSECURE_INFER_CONTEXT", "false").strip().lower() == "true"
 
 # Per-server Pebblo API key defaults (each server has its own key)
 ATLASSIAN_API_KEY = os.getenv("ATLASSIAN_API_KEY", "").strip() or None
@@ -172,15 +175,28 @@ def build_direct_mcp_servers(
     return servers
 
 
-def _get_chat_model() -> ChatOpenAI:
-    """Build ChatOpenAI using OpenAI directly (same as atlassian_langgraph_app)."""
-    return ChatOpenAI(model=MODEL or "gpt-4o-mini")
+def _get_chat_model(use_proxima: bool = False) -> ChatOpenAI:
+    """Build ChatOpenAI — optionally routed through SafeInfer/Proxima."""
+    kwargs = {"model": MODEL or "gpt-4o-mini"}
+    if use_proxima:
+        kwargs["base_url"] = f"{API_BASE_URL.rstrip('/')}/safe_infer/llm/v1/"
+        kwargs["api_key"] = API_KEY
+        default_headers = {}
+        if X_PEBBLO_USER:
+            default_headers["X-PEBBLO-USER"] = X_PEBBLO_USER
+        if X_PEBBLO_USER_GROUPS:
+            default_headers["X-PEBBLO-USER-GROUPS"] = X_PEBBLO_USER_GROUPS
+        if default_headers:
+            kwargs["default_headers"] = default_headers
+    print(f"Building ChatOpenAI with kwargs: {kwargs}")
+    return ChatOpenAI(**kwargs)
 
 
 async def setup_langgraph(
     mcp_servers: Dict[str, dict],
     pebblo_user: Optional[str] = None,
     pebblo_user_groups: Optional[str] = None,
+    use_proxima: bool = False,
 ):
     """Build and compile LangGraph bound to all provided MCP servers."""
     if not mcp_servers:
@@ -208,7 +224,7 @@ async def setup_langgraph(
         raise ValueError("No tools available — all configured MCP servers failed to connect.")
     logging.info(f"Retrieved {len(tools)} tools from MCP servers: {[tool.name for tool in tools]}")
     tools_by_name = {tool.name: tool for tool in tools}
-    chat_model = _get_chat_model()
+    chat_model = _get_chat_model(use_proxima=use_proxima)
     model_with_tools = chat_model.bind_tools(tools)
 
     async def async_tool_node(state: MessagesState):
@@ -289,10 +305,11 @@ async def stream_query_steps(
     mcp_servers: Dict[str, dict],
     pebblo_user: Optional[str] = None,
     pebblo_user_groups: Optional[str] = None,
+    use_proxima: bool = False,
 ):
     """Async generator: yields status lines and final answer while running the graph."""
     try:
-        graph = await setup_langgraph(mcp_servers, pebblo_user, pebblo_user_groups)
+        graph = await setup_langgraph(mcp_servers, pebblo_user, pebblo_user_groups, use_proxima=use_proxima)
         inputs = {"messages": [HumanMessage(content=user_input)]}
         yield "Analyzing your query..."
 

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -49,6 +49,9 @@ from mcp_utils import (
     SHOW_ATLASSIAN_OAUTH,
     SHOW_ATLASSIAN_DOCKER,
     SHOW_CUSTOMER_BILLING,
+    SAFE_INFER_CONTEXT,
+    INSECURE_INFER_CONTEXT,
+    USE_PROXIMA_FOR_INSECURE_AGENT,
     build_mcp_servers,
     build_direct_mcp_servers,
     stream_query_steps as mcp_stream_query_steps,
@@ -179,8 +182,8 @@ def stream_direct_openai(message: str, model: str) -> Generator:
 # Safe MCP helpers
 # ---------------------------------------------------------------------------
 
-async def _run_mcp_streaming(user_input: str, mcp_servers: dict, pebblo_user: str, pebblo_user_groups: str):
-    """Run Safe MCP query with streaming status updates."""
+async def _run_mcp_streaming(user_input: str, mcp_servers: dict, pebblo_user: str, pebblo_user_groups: str, use_proxima: bool = False):
+    """Run MCP query with streaming status updates."""
     current_response = ""
     tools_used = []
     intermediate_steps = []
@@ -192,6 +195,7 @@ async def _run_mcp_streaming(user_input: str, mcp_servers: dict, pebblo_user: st
         mcp_servers=mcp_servers,
         pebblo_user=pebblo_user or None,
         pebblo_user_groups=pebblo_user_groups or None,
+        use_proxima=use_proxima,
     ):
         if step_message.startswith("Final answer"):
             current_response = step_message.replace("Final answer: ", "")
@@ -239,9 +243,9 @@ async def _run_mcp_streaming(user_input: str, mcp_servers: dict, pebblo_user: st
         st.session_state.mcp_tools_used = tools_used
 
 
-def run_mcp_query(user_input: str, mcp_servers: dict, pebblo_user: str, pebblo_user_groups: str):
+def run_mcp_query(user_input: str, mcp_servers: dict, pebblo_user: str, pebblo_user_groups: str, use_proxima: bool = False):
     asyncio.run(
-        _run_mcp_streaming(user_input, mcp_servers, pebblo_user, pebblo_user_groups)
+        _run_mcp_streaming(user_input, mcp_servers, pebblo_user, pebblo_user_groups, use_proxima=use_proxima)
     )
 
 
@@ -643,43 +647,63 @@ if mode == "Safe Infer":
         send_button = st.button("🚀 Send", type="primary")
 
     if send_button and user_input.strip():
-        st.session_state.chat_history.append({
-            "role": "user",
-            "content": user_input,
-            "timestamp": time.strftime("%H:%M:%S"),
-        })
-        display_chat_message("user", user_input)
-
-        model = (st.session_state.get("selected_model") or "").strip()
-        if not model:
-            st.error("No model selected. Load models from API or enter a model ID.")
-            st.stop()
-
-        try:
-            with st.chat_message("assistant"):
-                response = st.write_stream(
-                    stream_open_ai(
-                        message=user_input,
-                        model=model,
-                        api_key=st.session_state.api_key,
-                    )
+        if SAFE_INFER_CONTEXT:
+            direct_mcp_servers = build_direct_mcp_servers(
+                atlassian_url=st.session_state.get("direct_atlassian_url", "") if SHOW_ATLASSIAN_DOCKER else "",
+                atlassian_oauth_url=st.session_state.get("direct_atlassian_oauth_url", "") if SHOW_ATLASSIAN_OAUTH else "",
+                atlassian_token=get_oauth_token("direct_atlassian") if SHOW_ATLASSIAN_OAUTH else None,
+                billing_url=st.session_state.get("direct_billing_url", "") if SHOW_CUSTOMER_BILLING else "",
+            )
+            if not direct_mcp_servers:
+                st.error("Configure at least one MCP server URL in the sidebar.")
+            else:
+                st.session_state.mcp_responses = []
+                st.session_state.mcp_tools_used = []
+                run_mcp_query(
+                    user_input=user_input,
+                    mcp_servers=direct_mcp_servers,
+                    pebblo_user="",
+                    pebblo_user_groups="",
+                    use_proxima=True,
                 )
+        else:
             st.session_state.chat_history.append({
-                "role": "assistant",
-                "content": response,
-                "model": st.session_state.selected_model,
+                "role": "user",
+                "content": user_input,
                 "timestamp": time.strftime("%H:%M:%S"),
             })
-        except Exception as e:
-            error_message = f"❌ Error: {str(e)}"
-            st.error(error_message)
-            st.session_state.chat_history.append({
-                "role": "assistant",
-                "content": error_message,
-                "timestamp": time.strftime("%H:%M:%S"),
-            })
+            display_chat_message("user", user_input)
 
-        st.rerun()
+            model = (st.session_state.get("selected_model") or "").strip()
+            if not model:
+                st.error("No model selected. Load models from API or enter a model ID.")
+                st.stop()
+
+            try:
+                with st.chat_message("assistant"):
+                    response = st.write_stream(
+                        stream_open_ai(
+                            message=user_input,
+                            model=model,
+                            api_key=st.session_state.api_key,
+                        )
+                    )
+                st.session_state.chat_history.append({
+                    "role": "assistant",
+                    "content": response,
+                    "model": st.session_state.selected_model,
+                    "timestamp": time.strftime("%H:%M:%S"),
+                })
+            except Exception as e:
+                error_message = f"❌ Error: {str(e)}"
+                st.error(error_message)
+                st.session_state.chat_history.append({
+                    "role": "assistant",
+                    "content": error_message,
+                    "timestamp": time.strftime("%H:%M:%S"),
+                })
+
+            st.rerun()
 
 elif mode == "InSecure Infer":
     for message in st.session_state.direct_chat_history:
@@ -702,39 +726,59 @@ elif mode == "InSecure Infer":
         direct_send = st.button("🚀 Send", type="primary", key="direct_send_btn")
 
     if direct_send and user_input_direct.strip():
-        st.session_state.direct_chat_history.append({
-            "role": "user",
-            "content": user_input_direct,
-            "timestamp": time.strftime("%H:%M:%S"),
-        })
-        display_chat_message("user", user_input_direct)
-
-        direct_model = (st.session_state.get("direct_model") or MODEL or "gpt-5").strip()
-
-        try:
-            with st.chat_message("assistant"):
-                response = st.write_stream(
-                    stream_direct_openai(
-                        message=user_input_direct,
-                        model=direct_model,
-                    )
+        if INSECURE_INFER_CONTEXT:
+            direct_mcp_servers = build_direct_mcp_servers(
+                atlassian_url=st.session_state.get("direct_atlassian_url", "") if SHOW_ATLASSIAN_DOCKER else "",
+                atlassian_oauth_url=st.session_state.get("direct_atlassian_oauth_url", "") if SHOW_ATLASSIAN_OAUTH else "",
+                atlassian_token=get_oauth_token("direct_atlassian") if SHOW_ATLASSIAN_OAUTH else None,
+                billing_url=st.session_state.get("direct_billing_url", "") if SHOW_CUSTOMER_BILLING else "",
+            )
+            if not direct_mcp_servers:
+                st.error("Configure at least one MCP server URL in the sidebar.")
+            else:
+                st.session_state.direct_mcp_responses = []
+                st.session_state.direct_mcp_tools_used = []
+                run_mcp_query(
+                    user_input=user_input_direct,
+                    mcp_servers=direct_mcp_servers,
+                    pebblo_user="",
+                    pebblo_user_groups="",
+                    use_proxima=False,
                 )
+        else:
             st.session_state.direct_chat_history.append({
-                "role": "assistant",
-                "content": response,
-                "model": direct_model,
+                "role": "user",
+                "content": user_input_direct,
                 "timestamp": time.strftime("%H:%M:%S"),
             })
-        except Exception as e:
-            error_message = f"❌ Error: {str(e)}"
-            st.error(error_message)
-            st.session_state.direct_chat_history.append({
-                "role": "assistant",
-                "content": error_message,
-                "timestamp": time.strftime("%H:%M:%S"),
-            })
+            display_chat_message("user", user_input_direct)
 
-        st.rerun()
+            direct_model = (st.session_state.get("direct_model") or MODEL or "gpt-5").strip()
+
+            try:
+                with st.chat_message("assistant"):
+                    response = st.write_stream(
+                        stream_direct_openai(
+                            message=user_input_direct,
+                            model=direct_model,
+                        )
+                    )
+                st.session_state.direct_chat_history.append({
+                    "role": "assistant",
+                    "content": response,
+                    "model": direct_model,
+                    "timestamp": time.strftime("%H:%M:%S"),
+                })
+            except Exception as e:
+                error_message = f"❌ Error: {str(e)}"
+                st.error(error_message)
+                st.session_state.direct_chat_history.append({
+                    "role": "assistant",
+                    "content": error_message,
+                    "timestamp": time.strftime("%H:%M:%S"),
+                })
+
+            st.rerun()
 
 elif mode == "InSecure Agent":
     if "direct_mcp_responses" not in st.session_state:
@@ -770,6 +814,7 @@ elif mode == "InSecure Agent":
                 mcp_servers=direct_mcp_servers,
                 pebblo_user="",
                 pebblo_user_groups="",
+                use_proxima=USE_PROXIMA_FOR_INSECURE_AGENT,
             )
 
 elif mode == "Safe Agent":

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -27,6 +27,7 @@ from utils import (
     FOOTER_HTML,
     MAIN_HEADER_HTML,
     MODEL,
+    PEBBLO_USERS_LIST,
     RESPONSE_API_ENDPOINT,
     X_PEBBLO_USER,
     X_PEBBLO_USER_GROUPS,
@@ -118,11 +119,12 @@ if "mcp_tools_used" not in st.session_state:
 # Safe Infer helpers
 # ---------------------------------------------------------------------------
 
-def stream_open_ai(message: str, model: str, api_key: str = ""):
+def stream_open_ai(message: str, model: str, api_key: str = "", pebblo_user: str = None):
     """Yield tokens from OpenAI-compatible completions API (streaming)."""
     default_headers = {}
-    if X_PEBBLO_USER:
-        default_headers["X-PEBBLO-USER"] = X_PEBBLO_USER
+    active_user = (pebblo_user or "").strip() or X_PEBBLO_USER
+    if active_user:
+        default_headers["X-PEBBLO-USER"] = active_user
     if X_PEBBLO_USER_GROUPS:
         default_headers["X-PEBBLO-USER-GROUPS"] = X_PEBBLO_USER_GROUPS
     default_headers = default_headers or None
@@ -299,6 +301,16 @@ with st.sidebar:
     mode = _LABEL_TO_MODE.get(_raw_mode, "Safe Agent")
 
     st.markdown("---")
+
+    if PEBBLO_USERS_LIST and mode in ("Safe Infer", "Safe Agent"):
+        st.subheader("👤 User")
+        st.selectbox(
+            "Select User",
+            options=PEBBLO_USERS_LIST,
+            key="selected_pebblo_user",
+            label_visibility="collapsed",
+        )
+        st.markdown("---")
 
     if mode == "Safe Infer":
         st.subheader("🔗 API Status")
@@ -548,7 +560,7 @@ with st.sidebar:
 
         def _pebblo_headers_for_oauth():
             return _pebblo_mcp_headers(
-                pebblo_user=st.session_state.get("mcp_user_input") or None,
+                pebblo_user=st.session_state.get("selected_pebblo_user") or None,
                 pebblo_user_groups=st.session_state.get("mcp_groups_input") or None,
             )
 
@@ -686,6 +698,7 @@ if mode == "Safe Infer":
                             message=user_input,
                             model=model,
                             api_key=st.session_state.api_key,
+                            pebblo_user=st.session_state.get("selected_pebblo_user") or None,
                         )
                     )
                 st.session_state.chat_history.append({
@@ -837,7 +850,7 @@ elif mode == "Safe Agent":
             atlassian_docker_api_key=st.session_state.get("atlassian_docker_api_key", "") if SHOW_ATLASSIAN_DOCKER else "",
             billing_url=st.session_state.get("billing_url", "") if SHOW_CUSTOMER_BILLING else "",
             billing_api_key=st.session_state.get("billing_api_key", "") if SHOW_CUSTOMER_BILLING else "",
-            pebblo_user=st.session_state.get("mcp_user_input", ""),
+            pebblo_user=st.session_state.get("selected_pebblo_user", ""),
             pebblo_user_groups=st.session_state.get("mcp_groups_input", ""),
             atlassian_token=get_oauth_token("atlassian") if SHOW_ATLASSIAN_OAUTH else None,
         )
@@ -849,7 +862,7 @@ elif mode == "Safe Agent":
             run_mcp_query(
                 user_input=mcp_query,
                 mcp_servers=mcp_servers,
-                pebblo_user=st.session_state.get("mcp_user_input", ""),
+                pebblo_user=st.session_state.get("selected_pebblo_user", ""),
                 pebblo_user_groups=st.session_state.get("mcp_groups_input", ""),
             )
 

--- a/daxa_chatbot_app/utils.py
+++ b/daxa_chatbot_app/utils.py
@@ -32,6 +32,7 @@ RESPONSE_API_ENDPOINT = f"{API_BASE_URL}/safe_infer/llm/v1/"
 LLM_PROVIDER_API_ENDPOINT = f"{API_BASE_URL}/api/llm/provider"
 X_PEBBLO_USER = os.getenv("X_PEBBLO_USER", None)
 X_PEBBLO_USER_GROUPS = os.getenv("X_PEBBLO_USER_GROUPS", None)
+PEBBLO_USERS_LIST = [u.strip() for u in os.getenv("PEBBLO_USERS", "").split(",") if u.strip()]
 MODEL = os.getenv("MODEL", "").strip()
 
 CUSTOM_CSS = """


### PR DESCRIPTION

### Overview

This PR introduces feature flags to optionally route the **Safe Infer** and **InSecure Infer** chat modes through the MCP agent pipeline, mirroring the Insecure Agent's behavior. It also adds a flag to route the **Insecure Agent's LLM call** through the SafeInfer/Proxima gateway. All flags are opt-in and default to `false`, preserving existing behavior unless explicitly enabled.

---

### Motivation

Previously, the Safe Infer and InSecure Infer modes were simple chat interfaces with no tool/MCP support. To enable testing of Proxima's content inspection and SafeInfer capabilities within these modes — without modifying the dedicated Safe Agent and Insecure Agent modes — feature flags were added to selectively activate the full MCP pipeline.

---

### Feature Flags

| Flag | Mode | Behavior when `true` |
|------|------|----------------------|
| `USE_PROXIMA_FOR_INSECURE_AGENT` | Insecure Agent | Routes the LLM call through SafeInfer (`{PROXIMA_HOST}/safe_infer/llm/v1/`) instead of direct OpenAI |
| `SAFE_INFER_CONTEXT` | Safe Infer | Replaces `stream_open_ai` with Insecure Agent MCP pipeline (direct MCP servers) + LLM via SafeInfer |
| `INSECURE_INFER_CONTEXT` | InSecure Infer | Replaces `stream_direct_openai` with Insecure Agent MCP pipeline (direct MCP servers) + direct OpenAI |

All flags default to `false`.

---

### Architecture

#### `_get_chat_model(use_proxima: bool = False)`

Refactored from a no-arg function that read a global flag to a parameterized function. When `use_proxima=True`:
- Sets `base_url` to `{PROXIMA_HOST}/safe_infer/llm/v1/`
- Passes `api_key=API_KEY` (OpenAI SDK sends this as `Authorization: Bearer`)
- Attaches `X-PEBBLO-USER` / `X-PEBBLO-USER-GROUPS` as `default_headers`

#### Parameter threading

`use_proxima` is threaded top-down through:
```
run_mcp_query(use_proxima)
  └── _run_mcp_streaming(use_proxima)
        └── stream_query_steps(use_proxima)
              └── setup_langgraph(use_proxima)
                    └── _get_chat_model(use_proxima)
```

#### MCP server config

When `SAFE_INFER_CONTEXT=true` or `INSECURE_INFER_CONTEXT=true`, the Infer modes use `build_direct_mcp_servers()` (same as Insecure Agent) — no Proxima gateway headers, no Pebblo auth on MCP connections. The MCP server URLs are read from the same session state keys (`direct_atlassian_url`, `direct_billing_url`, etc.) already populated by the Insecure Agent sidebar.

---

### Files Changed

**`mcp_utils.py`**
- Added `SAFE_INFER_CONTEXT`, `INSECURE_INFER_CONTEXT` module-level flags (alongside existing `USE_PROXIMA_FOR_INSECURE_AGENT`)
- Refactored `_get_chat_model()` → `_get_chat_model(use_proxima: bool = False)`
- Added `use_proxima` param to `setup_langgraph()` and `stream_query_steps()`

**`safe_infer_chatbot.py`**
- Imported `SAFE_INFER_CONTEXT`, `INSECURE_INFER_CONTEXT`, `USE_PROXIMA_FOR_INSECURE_AGENT`
- Added `use_proxima` param to `_run_mcp_streaming()` and `run_mcp_query()`
- Safe Infer send block: conditionally routes through MCP pipeline when `SAFE_INFER_CONTEXT=true`
- InSecure Infer send block: conditionally routes through MCP pipeline when `INSECURE_INFER_CONTEXT=true`
- Insecure Agent send block: passes `use_proxima=USE_PROXIMA_FOR_INSECURE_AGENT`

**`.env.example`**
- Added `USE_PROXIMA_FOR_INSECURE_AGENT=`, `SAFE_INFER_CONTEXT=`, `INSECURE_INFER_CONTEXT=` under the feature flags section

---

### Testing

- [ ] `USE_PROXIMA_FOR_INSECURE_AGENT=false` (default) — Insecure Agent calls direct OpenAI, no regression
- [ ] `USE_PROXIMA_FOR_INSECURE_AGENT=true` — Insecure Agent LLM routes through `{PROXIMA_HOST}/safe_infer/llm/v1/`
- [ ] `SAFE_INFER_CONTEXT=false` (default) — Safe Infer uses `stream_open_ai`, no regression
- [ ] `SAFE_INFER_CONTEXT=true` — Safe Infer uses direct MCP servers + SafeInfer LLM
- [ ] `INSECURE_INFER_CONTEXT=false` (default) — InSecure Infer uses `stream_direct_openai`, no regression
- [ ] `INSECURE_INFER_CONTEXT=true` — InSecure Infer uses direct MCP servers + direct OpenAI