### PR TITLE
MCP Fixes and SafeInfer Dynamic Model Selection

### DIFF
--- a/daxa_chatbot_app/mcp_utils.py
+++ b/daxa_chatbot_app/mcp_utils.py
@@ -128,7 +128,7 @@ def build_mcp_servers(
     if a_url:
         servers["atlassian"] = {
             "url": a_url,
-            "transport": "sse",
+            "transport": "streamable_http",
             "headers": _headers_for(atlassian_api_key or ATLASSIAN_API_KEY, atlassian_token),
         }
 
@@ -231,6 +231,22 @@ async def setup_langgraph(
     logging.info(f"Retrieved {len(tools)} tools (incl. local fetch_web_page): {[t.name for t in tools]}")
     tools_by_name = {t.name: t for t in tools}
     chat_model = _get_chat_model()
+    SYSTEM_PROMPT = """You are an AI assistant with access to Jira, Confluence, and web tools.
+
+CRITICAL: When the user asks about tickets, issues, confluence pages, or anything related to enterprise systems:
+1. ALWAYS use the domain-specific Jira/Confluence tools first
+2. NEVER use generic 'search' or 'fetch' for enterprise queries
+3. Use getJiraIssue, searchJiraIssuesUsingJql, getConfluencePage, searchConfluenceUsingCql, etc.
+
+Tool categories:
+- Jira: getJiraIssue, searchJiraIssuesUsingJql, createJiraIssue, editJiraIssue, transitionJiraIssue, addCommentToJiraIssue, lookupJiraAccountId, getVisibleJiraProjects, etc.
+- Confluence: getConfluencePage, searchConfluenceUsingCql, createConfluencePage, updateConfluencePage, getConfluenceSpaces, etc.
+- Web: fetch_web_page (only for external URLs, not internal systems)
+- Generic: search, fetch (only as last resort for unstructured queries)
+
+Always prefer Jira/Confluence tools over generic tools."""
+
+    # model_with_tools = chat_model.bind_tools(tools, system_prompt=system_prompt)
     model_with_tools = chat_model.bind_tools(tools)
 
     async def async_tool_node(state: MessagesState):
@@ -263,7 +279,10 @@ async def setup_langgraph(
 
     async def call_model(state: MessagesState):
         logging.info("[Graph] call_model: invoking LLM with %d messages", len(state["messages"]))
-        response = await model_with_tools.ainvoke(state["messages"])
+        messages_with_system = [
+            {"role": "system", "content": SYSTEM_PROMPT}
+        ] + state["messages"]
+        response = await model_with_tools.ainvoke(messages_with_system)
         logging.info("[Graph] call_model: response type=%s, tool_calls=%s",
                      type(response).__name__,
                      [tc["name"] for tc in response.tool_calls] if hasattr(response, "tool_calls") and response.tool_calls else [])

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -597,7 +597,7 @@ with st.sidebar:
             ("Threat Protection",                   "Tell me details about KAN-19"),
             ("Data Privacy: Topics (Custom)",       "Tell me details about KAN-47."),
             ("Data Privacy: Entities (Redact)",     "Give me details of KAN-46"),
-            ("Agent Access : Destructive Actions",  "Delete following jira ticket - KAN-25."),
+            ("Agent Access : Destructive Actions",  "Delete following jira ticket - KAN-50."),
             # ("Data Privacy: Topics (Health)",       "Tell me details about KAN-22"),
         ]
         for _lbl, _txt in _AGENT_PROMPTS:

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -495,8 +495,8 @@ with st.sidebar:
         _INSECURE_AGENT_PROMPTS = [
             ("Threat Protection",                   "Tell me details about KAN-19"),
             ("Data Privacy: Topics (Custom)",       "Tell me details about KAN-47."),
-            # ("Data Privacy: Entities (Redact)",     "Give me details of KAN-46"),
-            ("Agent Access : Destructive Actions",  "Delete following jira ticket - KAN-25."),
+            ("Agent Access : Destructive Actions",  "Delete following jira ticket - KAN-50."),
+            ("Data Privacy: Entities (Redact)",     "Give me details of KAN-46"),
             # ("Data Privacy: Topics (Health)",       "Tell me details about KAN-22"),
         ]
         for _lbl, _txt in _INSECURE_AGENT_PROMPTS:
@@ -596,8 +596,8 @@ with st.sidebar:
         _AGENT_PROMPTS = [
             ("Threat Protection",                   "Tell me details about KAN-19"),
             ("Data Privacy: Topics (Custom)",       "Tell me details about KAN-47."),
-            ("Data Privacy: Entities (Redact)",     "Give me details of KAN-46"),
             ("Agent Access : Destructive Actions",  "Delete following jira ticket - KAN-50."),
+            ("Data Privacy: Entities (Redact)",     "Give me details of KAN-46"),
             # ("Data Privacy: Topics (Health)",       "Tell me details about KAN-22"),
         ]
         for _lbl, _txt in _AGENT_PROMPTS:

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -495,7 +495,7 @@ with st.sidebar:
         _INSECURE_AGENT_PROMPTS = [
             ("Threat Protection",                   "Tell me details about KAN-19"),
             ("Data Privacy: Topics (Custom)",       "Tell me details about KAN-47."),
-            ("Data Privacy: Entities (Redact)",     "Give me details of KAN-46"),
+            # ("Data Privacy: Entities (Redact)",     "Give me details of KAN-46"),
             ("Agent Access : Destructive Actions",  "Delete following jira ticket - KAN-25."),
             # ("Data Privacy: Topics (Health)",       "Tell me details about KAN-22"),
         ]

--- a/daxa_chatbot_app/safe_infer_chatbot.py
+++ b/daxa_chatbot_app/safe_infer_chatbot.py
@@ -734,17 +734,17 @@ with st.sidebar:
         model_names, default_model = fetch_models()
         model_names = merge_env_model_into_model_list(model_names, MODEL)
         if model_names:
-            try:
+            # Set default only on first render; after that the widget key owns its state.
+            if "sidebar_model_select" not in st.session_state:
                 current = st.session_state.get("selected_model") or MODEL or default_model
                 if current not in model_names:
                     current = default_model or model_names[0]
-                idx = model_names.index(current) if current in model_names else 0
-            except (ValueError, TypeError):
-                idx = 0
+                st.session_state["sidebar_model_select"] = current
+            elif st.session_state["sidebar_model_select"] not in model_names:
+                st.session_state["sidebar_model_select"] = default_model or model_names[0]
             selected_model = st.selectbox(
                 "LLM Model",
                 model_names,
-                index=idx,
                 key="sidebar_model_select",
                 label_visibility="collapsed",
             )


### PR DESCRIPTION
1. **MCP Transport** — `mcp_utils.py`
Changed the Atlassian MCP server transport from `sse` to `streamable_http`. This applies to the build_mcp_servers function and aligns with the updated MCP server protocol.

2. **LangGraph System Prompt** — `mcp_utils.py`
Added a SYSTEM_PROMPT inside setup_langgraph that instructs the LLM to:
Always prefer Jira/Confluence-specific tools (`getJiraIssue`, `searchJiraIssuesUsingJql`, `getConfluencePage`, `searchConfluenceUsingCql`, etc.) for enterprise queries
Avoid generic `search`/`fetch` for internal system queries
Use `fetch_web_page` only for external URLs
The system prompt is prepended to every call_model invocation in the LangGraph graph.

3. **Safe Infer Model Selection Fix** — `safe_infer_chatbot.py`
Fixed a Streamlit bug where the model dropdown was silently reverting to the default model on every rerun.
**Root cause:** `index=idx` was being recomputed from `st.session_state.selected_model` on every script rerun, causing Streamlit to re-impose the old index and override the user's selection.
**Fix:** Seed `st.session_state["sidebar_model_select"]` once on first render, then let the widget's key own its state on subsequent reruns. The index= argument is removed entirely so Streamlit stops overriding the user's choice.