### PR TITLE
Deck Builder App: multi-file pipeline, docx support, timing, and topic-based file routing

### DIFF
--- a/deck_builder_app/.env.example
+++ b/deck_builder_app/.env.example
@@ -44,6 +44,12 @@ DECK_SOURCE_DIR=static/source_files
 #     file never prevents the rest of the deck from being generated.
 ENABLE_MULTI_PASS=false
 
+# Optional: filename -> topic description, so the system prompt can route a
+# question to the relevant file(s) instead of blending everything together.
+# Python dict literal. Example:
+# FILE_TOPIC_HINTS={'Board Meeting Summary Doc.docx': 'questions about the board meeting', 'client_data_with_finance_v3.xlsx': 'questions about client finance'}
+FILE_TOPIC_HINTS={}
+
 # ── Debug ─────────────────────────────────────────────────────────────────────
 # true = append a "⏱ Timing" breakdown to every response (parse/call durations).
 # Off by default — this is a diagnostic aid, not something end users need to see.

--- a/deck_builder_app/deck_builder.py
+++ b/deck_builder_app/deck_builder.py
@@ -76,6 +76,34 @@ try:
 except Exception:
     _DOC_ACCESS_ALLOWED = {}
 
+# Optional filename -> topic description hints, e.g.
+# {'Board Meeting Summary Doc.docx': 'questions about the board meeting'}.
+# Injected into the system prompt so the LLM routes a question to the
+# relevant file(s) among whatever content is actually included that turn,
+# rather than blending unrelated files together.
+_raw_file_topics = os.getenv("FILE_TOPIC_HINTS", "").strip()
+try:
+    _FILE_TOPIC_HINTS: dict = ast.literal_eval(_raw_file_topics) if _raw_file_topics else {}
+    if not isinstance(_FILE_TOPIC_HINTS, dict):
+        _FILE_TOPIC_HINTS = {}
+except Exception:
+    _FILE_TOPIC_HINTS = {}
+
+
+def _file_topic_hint_clause() -> str:
+    """Build a system-prompt clause routing questions to the relevant file(s),
+    or "" if FILE_TOPIC_HINTS isn't configured."""
+    if not _FILE_TOPIC_HINTS:
+        return ""
+    mapping = "; ".join(f"'{fname}' is for {topic}" for fname, topic in _FILE_TOPIC_HINTS.items())
+    return (
+        f" Some files map to specific topics: {mapping}. When the user's question "
+        "clearly relates to one of these topics, use ONLY the matching file's "
+        "content (ignore the other files' content); if the question doesn't "
+        "match any listed topic, or several files are relevant, use whichever "
+        "file(s) actually apply based on their content."
+    )
+
 
 def _is_file_readable(file_path: str, pebblo_user_groups: str) -> bool:
     """Return True if the user may see/use file_path.
@@ -228,6 +256,7 @@ _FILENAME_HINT = (
     "details, and a file whose name contains 'client' holds client details — use "
     "this to correctly label and organize the corresponding content."
 )
+_FILE_TOPIC_HINT = _file_topic_hint_clause()
 
 DECK_SYSTEM_PROMPT = (
     "You are a slide deck generation assistant. Given file content (spreadsheet "
@@ -241,7 +270,7 @@ DECK_SYSTEM_PROMPT = (
     "information or PII), do not attempt to guess or reconstruct the original "
     "values — build the outline using the masked values as given, and add a brief "
     "note at the end of the outline flagging which field(s) appeared masked. "
-    f"{_FILENAME_HINT}"
+    f"{_FILENAME_HINT}{_FILE_TOPIC_HINT}"
 )
 
 MAP_SYSTEM_PROMPT = (
@@ -253,7 +282,7 @@ MAP_SYSTEM_PROMPT = (
     "concise (a handful of bullet points, no heading needed). If any values appear "
     "masked or redacted (e.g. asterisks, '[REDACTED]', 'XXXX'), do not guess the "
     "original value — use it as given and note which field(s) appeared masked. "
-    f"{_FILENAME_HINT}"
+    f"{_FILENAME_HINT}{_FILE_TOPIC_HINT}"
 )
 
 REDUCE_SYSTEM_PROMPT = (
@@ -264,7 +293,7 @@ REDUCE_SYSTEM_PROMPT = (
     "notes and the user's stated goal. If any note mentions a masked or redacted "
     "field, preserve that mention rather than guessing the real value. If no notes "
     "were provided, produce a reasonable outline from the instructions alone and "
-    f"say so briefly at the top. {_FILENAME_HINT}"
+    f"say so briefly at the top. {_FILENAME_HINT}{_FILE_TOPIC_HINT}"
 )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #36 (merged) — adds the multi-file source pipeline plus several refinements, all in `deck_builder_app/`:

- **Folder-iteration pipeline**: when no file is uploaded, every eligible file in a configurable source-files folder (`DECK_SOURCE_DIR`, nested under `static/` so the sidebar can link to them) is used to generate the deck instead of requiring a manual upload each time.
  - **Single pass (default)** — all eligible files' content combined into one prompt, one LLM call. Fastest option.
  - **Multi pass** (`ENABLE_MULTI_PASS=true`) — one call per file, skipping any that errors (in particular an HTTP 403 — Safe Infer blocking that file's content), then a final call combines whatever succeeded. Slower (N+1 calls) but a single blocked/failed file never prevents the rest of the deck from being generated.
  - Uploading a file via the widget (now folded under a collapsible "📎 Upload a file" section) bypasses the folder entirely for that turn.
  - Per-file group access control (`DOC_ACCESS_ALLOWED`) applies to processing, not just the sidebar listing.
- **`.docx` support**: `file_parser.py` now handles Word documents (via `python-docx`) alongside `.xlsx`/`.xlsm`, behind a unified `parse_file_to_text()` dispatcher.
- **Topic-based file routing**: new optional `FILE_TOPIC_HINTS` env var (filename -> topic description, same style as `DOC_ACCESS_ALLOWED`) injected into the system prompts so a question that clearly matches one topic uses only that file's content instead of blending every source file together.
- **Filename-based labeling**: system prompts recognize "employee"/"client" in filenames to correctly label and organize the corresponding deck sections.
- **Diagnostics**: optional `DEBUG=true` appends a deterministic "⏱ Timing" breakdown (parse/call durations, time-to-first-token) to every response — off by default so it never surfaces to end users.
- Insecure Inference mode shares the exact same generation pipeline as Safe Infer (single call, folder iteration, timing) — only the client/endpoint differs.

## Test plan
- [x] `python -m py_compile` on all modules
- [x] `streamlit.testing.v1.AppTest` runs across both modes: no exceptions, mode switching, upload-bypasses-folder-iteration, non-supported/corrupt-file handling
- [x] `file_parser` unit-tested: multi-sheet `.xlsx`, `.docx` (paragraphs + tables), corrupt files, empty files, unsupported extensions
- [x] Manually verified end-to-end against two live gateways (including a mocked HTTP 403 to confirm skip-and-continue behavior in multi-pass mode) and OpenAI direct
- [x] Verified single-pass vs multi-pass timing difference, and that a real model swap (Anthropic vs OpenAI vs Qwen) is the dominant timing factor, not gateway overhead
- [x] Verified `FILE_TOPIC_HINTS` correctly routes a question to the matching file's content only
- [x] Confirmed `DEBUG=false` (default) fully suppresses the timing footer; `DEBUG=true` shows it
- [ ] Reviewer: `pip install -r deck_builder_app/requirements.txt && streamlit run deck_builder_app/deck_builder.py` with your own `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)