### PR TITLE
Add per-session multi-env support to deck builder app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .env
 **/.env
+**/.env.*
+**/.env-*
+deck_builder_app/.settings_overrides.json
 kiran.env
 __pycache__/
 *.py[cod]

--- a/deck_builder_app/.env.example
+++ b/deck_builder_app/.env.example
@@ -1,4 +1,8 @@
-# Deck Builder App
+# Deck Builder App — per-environment config
+# Copy this file to .env.demo-1, .env.demo-2, etc. and fill in values per env.
+# Register each env in envs.json: {"demo-1": ".env.demo-1", ...}
+# Switch envs in the browser via ?env=demo-1 in the URL.
+ENV_NAME=
 PEBBLO_API_KEY=
 PROXIMA_HOST=
 USER_EMAIL=

--- a/deck_builder_app/deck_builder.py
+++ b/deck_builder_app/deck_builder.py
@@ -14,14 +14,9 @@ from openai import APIStatusError, OpenAI
 
 from file_parser import FileParsingError, is_supported_file, parse_file_to_text
 from utils import (
-    API_BASE_URL,
-    API_KEY,
     CUSTOM_CSS,
     FOOTER_HTML,
     MAIN_HEADER_HTML,
-    MODEL,
-    PEBBLO_USER_GROUPS_MAP,
-    PEBBLO_USERS_LIST,
     X_PEBBLO_USER,
     X_PEBBLO_USER_GROUPS,
     display_chat_message,
@@ -33,6 +28,15 @@ from utils import (
     load_prompts_from_yaml,
     merge_env_model_into_model_list,
     test_api_connection,
+)
+from env_config import (
+    get_api_key,
+    get_debug_enabled,
+    get_env_name,
+    get_model,
+    get_pebblo_user_groups_map,
+    get_pebblo_users_list,
+    get_proxima_host,
 )
 
 # ---------------------------------------------------------------------------
@@ -65,9 +69,6 @@ DECK_SOURCE_DIR = _raw_source_dir if os.path.isabs(_raw_source_dir) else os.path
 # Safe Infer blocking that file), then a final call combines whatever succeeded.
 MULTI_PASS_ENABLED = os.getenv("ENABLE_MULTI_PASS", "false").strip().lower() == "true"
 
-# Set DEBUG=true to append a "⏱ Timing" breakdown to every response. Off by
-# default — this is a diagnostic aid, not something end users need to see.
-DEBUG_ENABLED = os.getenv("DEBUG", "false").strip().lower() == "true"
 
 _raw_access = os.getenv("DOC_ACCESS_ALLOWED", "").strip()
 try:
@@ -489,7 +490,7 @@ def run_deck_pipeline(client: OpenAI, model: str, user_input: str, augmented_upl
     if augmented_upload_content is not None:
         timing: dict = {}
         yield from _call_stream(client, model, DECK_SYSTEM_PROMPT, augmented_upload_content, timing=timing)
-        if DEBUG_ENABLED:
+        if get_debug_enabled():
             total_s = time.perf_counter() - pipeline_start
             yield f"\n\n---\n*{_timing_note('LLM call', timing, total_s)}*"
         return
@@ -507,7 +508,7 @@ def run_deck_pipeline(client: OpenAI, model: str, user_input: str, augmented_upl
             note_parts.append(f"{len(topic_excluded)} file(s) excluded as not relevant to this question: {', '.join(fname for fname, _ in topic_excluded)}")
         if note_parts:
             trailer.append(f"*Note: {'; '.join(note_parts)}.*")
-        if DEBUG_ENABLED:
+        if get_debug_enabled():
             total_s = time.perf_counter() - pipeline_start
             trailer.append(f"*{_timing_note('LLM call', timing, total_s)}*")
         if trailer:
@@ -519,7 +520,7 @@ def run_deck_pipeline(client: OpenAI, model: str, user_input: str, augmented_upl
         reduce_timing: dict = {}
         yield from _reduce_stream(client, model, partials, user_input, skipped, locked, topic_excluded, timing=reduce_timing)
 
-        if DEBUG_ENABLED:
+        if get_debug_enabled():
             total_s = time.perf_counter() - pipeline_start
             parse_total = sum(p for _, p, _ in file_timings)
             map_call_total = sum(c for _, _, c in file_timings)
@@ -552,7 +553,7 @@ def run_deck_pipeline(client: OpenAI, model: str, user_input: str, augmented_upl
     trailer = []
     if note_parts:
         trailer.append(f"*Note: {'; '.join(note_parts)}.*")
-    if DEBUG_ENABLED:
+    if get_debug_enabled():
         total_s = time.perf_counter() - pipeline_start
         first = timing.get("first_token_s")
         first_part = f" (first token {_fmt_secs(first)})" if first is not None else ""
@@ -574,7 +575,7 @@ def stream_deck_builder(
     pebblo_user_groups: str = "",
 ):
     """Safe Infer: routed through the Daxa gateway with Pebblo headers."""
-    client = get_llm_client(api_key or API_KEY, pebblo_user=pebblo_user, pebblo_user_groups=pebblo_user_groups)
+    client = get_llm_client(api_key or get_api_key(), pebblo_user=pebblo_user, pebblo_user_groups=pebblo_user_groups)
     yield from run_deck_pipeline(client, model, user_input, augmented_upload_content, pebblo_groups=pebblo_user_groups or None)
 
 
@@ -592,8 +593,8 @@ def stream_deck_builder_direct(user_input: str, model: str, augmented_upload_con
 # ---------------------------------------------------------------------------
 
 @st.cache_data(ttl=300)
-def fetch_models():
-    """Fetch models from GET .../v1/models (cached 5 min). Returns (names, default_id)."""
+def fetch_models(env_name: str = ""):
+    """Fetch models from GET .../v1/models (cached 5 min per env). Returns (names, default_id)."""
     return get_available_models()
 
 
@@ -627,23 +628,36 @@ if "chat_history" not in st.session_state:
     st.session_state.chat_history = []
 if "direct_chat_history" not in st.session_state:
     st.session_state.direct_chat_history = []
-if "selected_model" not in st.session_state:
-    st.session_state.selected_model = MODEL or ""
-if "api_key" not in st.session_state:
-    st.session_state.api_key = API_KEY
 if "model_name" not in st.session_state:
     st.session_state.model_name = ""
 if "prompt_language" not in st.session_state:
     st.session_state.prompt_language = DEFAULT_LANGUAGE
-if "selected_pebblo_user" not in st.session_state:
-    st.session_state.selected_pebblo_user = PEBBLO_USERS_LIST[0] if PEBBLO_USERS_LIST else (X_PEBBLO_USER or "")
+
+# Reset env-dependent state whenever ?env= changes between reruns.
+# On first load, _active_env is absent so the block always fires once.
+_active_env = st.query_params.get("env", "")
+if st.session_state.get("_active_env") != _active_env:
+    st.session_state._active_env = _active_env
+    _users = get_pebblo_users_list()
+    st.session_state.selected_model = get_model() or ""
+    st.session_state.api_key = get_api_key()
+    st.session_state.selected_pebblo_user = _users[0] if _users else (X_PEBBLO_USER or "")
+else:
+    if "selected_model" not in st.session_state:
+        st.session_state.selected_model = get_model() or ""
+    if "api_key" not in st.session_state:
+        st.session_state.api_key = get_api_key()
+    if "selected_pebblo_user" not in st.session_state:
+        _users = get_pebblo_users_list()
+        st.session_state.selected_pebblo_user = _users[0] if _users else (X_PEBBLO_USER or "")
 
 
 def _get_active_pebblo_groups() -> str:
     """Return user-groups string for the selected user, falling back to env default."""
     user = st.session_state.get("selected_pebblo_user", "")
-    if user and PEBBLO_USER_GROUPS_MAP:
-        mapped = PEBBLO_USER_GROUPS_MAP.get(user, "")
+    groups_map = get_pebblo_user_groups_map()
+    if user and groups_map:
+        mapped = groups_map.get(user, "")
         if mapped:
             return mapped
     return X_PEBBLO_USER_GROUPS or ""
@@ -696,7 +710,9 @@ def _render_prompt_language_and_samples() -> None:
 # ---------------------------------------------------------------------------
 
 with st.sidebar:
-    st.caption(f"🔗 Target: {API_BASE_URL}")
+    st.caption(f"🔗 Target: {get_proxima_host()}")
+    _env_label = _active_env or get_env_name() or "default"
+    st.caption(f"🌍 Env: `{_env_label}`")
     st.markdown("---")
 
     _raw_mode = st.segmented_control(
@@ -710,11 +726,12 @@ with st.sidebar:
     st.markdown("---")
 
     if mode == "Safe Infer":
-        if PEBBLO_USERS_LIST:
+        _users = get_pebblo_users_list()
+        if _users:
             st.subheader("👤 User")
             st.selectbox(
                 "User",
-                options=PEBBLO_USERS_LIST,
+                options=_users,
                 format_func=format_display_name,
                 key="selected_pebblo_user",
                 label_visibility="collapsed",
@@ -731,11 +748,11 @@ with st.sidebar:
                     st.error(result["message"])
 
         st.subheader("🤖 Model")
-        model_names, default_model = fetch_models()
-        model_names = merge_env_model_into_model_list(model_names, MODEL)
+        model_names, default_model = fetch_models(_active_env)
+        model_names = merge_env_model_into_model_list(model_names, get_model())
         if model_names:
             try:
-                current = st.session_state.get("selected_model") or MODEL or default_model
+                current = st.session_state.get("selected_model") or get_model() or default_model
                 if current not in model_names:
                     current = default_model or model_names[0]
                 idx = model_names.index(current) if current in model_names else 0
@@ -752,7 +769,7 @@ with st.sidebar:
             st.session_state.model_name = selected_model
         else:
             st.warning("Could not load models from API. Enter a model ID below.")
-            fallback = st.session_state.get("selected_model") or MODEL or ""
+            fallback = st.session_state.get("selected_model") or get_model() or ""
             manual = st.text_input(
                 "Model ID",
                 value=fallback,
@@ -763,7 +780,7 @@ with st.sidebar:
                 st.session_state.selected_model = manual.strip()
                 st.session_state.model_name = manual.strip()
         if st.button("Refresh models", key="refresh_models_main"):
-            fetch_models.clear()
+            fetch_models.clear()  # clears all env caches
             st.rerun()
 
         _render_prompt_language_and_samples()
@@ -783,7 +800,7 @@ with st.sidebar:
 
     elif mode == "Insecure Inference":
         st.subheader("🤖 Model")
-        _direct_model_val = st.session_state.get("direct_model") or MODEL or "gpt-5"
+        _direct_model_val = st.session_state.get("direct_model") or get_model() or "gpt-5"
         st.text_input(
             "Model ID",
             value=_direct_model_val,
@@ -938,7 +955,7 @@ elif mode == "Insecure Inference":
         })
         display_chat_message("user", display_content)
 
-        direct_model = (st.session_state.get("direct_model") or MODEL or "gpt-5").strip()
+        direct_model = (st.session_state.get("direct_model") or get_model() or "gpt-5").strip()
 
         try:
             with st.chat_message("assistant"):

--- a/deck_builder_app/env_config.py
+++ b/deck_builder_app/env_config.py
@@ -1,0 +1,105 @@
+"""Per-session environment configuration loaded from .env files via dotenv_values().
+
+Unlike load_dotenv() — which writes to os.environ and is shared across all
+Streamlit sessions in the same process — dotenv_values() reads into a plain
+dict per call. Multiple concurrent sessions can therefore use different
+environments simultaneously without interfering with each other.
+
+Usage:
+    Populate envs.json with a mapping of env-name -> .env file path:
+        {"demo-1": ".env.demo-1", "demo-2": ".env.demo-2"}
+
+    Set ?env=demo-1 in the browser URL. The app loads .env.demo-1 for that
+    session. With no ?env= param, falls back to the default .env file.
+"""
+import json
+import os
+import re
+
+from dotenv import dotenv_values
+
+_APP_DIR = os.path.dirname(__file__)
+_ENV_MAP_PATH = os.path.join(_APP_DIR, "envs.json")
+_DEFAULT_ENV_FILE = os.path.join(_APP_DIR, ".env")
+_SAFE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _load_env_map() -> dict:
+    """Read envs.json — maps env-name to .env file path. Returns {} if missing/corrupt."""
+    if not os.path.isfile(_ENV_MAP_PATH):
+        return {}
+    try:
+        with open(_ENV_MAP_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def get_session_config() -> dict:
+    """Return the env-var dict for the current Streamlit session.
+
+    Reads ?env= from st.query_params, resolves the matching .env file via
+    envs.json, and returns dotenv_values() for that file. Falls back to the
+    default .env when the param is absent or not listed in envs.json.
+
+    Never calls load_dotenv() — os.environ is never modified — so concurrent
+    sessions on different environments do not interfere with each other.
+    """
+    import streamlit as st  # lazy: keeps this module importable outside Streamlit
+
+    env_name = st.query_params.get("env", "").strip()
+    env_file = _DEFAULT_ENV_FILE
+    if env_name and _SAFE_NAME.match(env_name):
+        env_map = _load_env_map()
+        if env_name in env_map:
+            candidate = env_map[env_name]
+            if not os.path.isabs(candidate):
+                candidate = os.path.join(_APP_DIR, candidate)
+            if os.path.isfile(candidate):
+                env_file = candidate
+    return dict(dotenv_values(env_file))
+
+
+# ---------------------------------------------------------------------------
+# Typed accessors — each re-evaluates on every call (no caching)
+# ---------------------------------------------------------------------------
+
+def get_proxima_host() -> str:
+    raw = get_session_config().get("PROXIMA_HOST", "http://localhost")
+    return (raw or "http://localhost").rstrip("/")
+
+
+def get_response_api_endpoint() -> str:
+    return f"{get_proxima_host()}/safe_infer/llm/v1/"
+
+
+def get_api_key() -> str:
+    return get_session_config().get("PEBBLO_API_KEY", "")
+
+
+def get_model() -> str:
+    return (get_session_config().get("MODEL") or "").strip()
+
+
+def get_pebblo_users_list() -> list:
+    raw = get_session_config().get("PEBBLO_USERS", "")
+    return [u.strip() for u in raw.split(",") if u.strip()]
+
+
+def get_pebblo_user_groups_map() -> dict:
+    from utils import _parse_user_groups_map  # lazy import avoids circular dependency
+    return _parse_user_groups_map(get_session_config().get("PEBBLO_USER_GROUPS_MAP", ""))
+
+
+def get_env_name() -> str:
+    return get_session_config().get("ENV_NAME", "").strip()
+
+
+def get_debug_enabled() -> bool:
+    return get_session_config().get("DEBUG", "false").strip().lower() == "true"
+
+
+def list_available_envs() -> list:
+    """Return sorted list of env names defined in envs.json."""
+    return sorted(_load_env_map().keys())

--- a/deck_builder_app/envs.json
+++ b/deck_builder_app/envs.json
@@ -1,0 +1,4 @@
+{
+  "hpe-demo-2": ".env.hpe-demo-2",
+  "demo-1": ".env-demo-1"
+}

--- a/deck_builder_app/utils.py
+++ b/deck_builder_app/utils.py
@@ -21,18 +21,17 @@ from dotenv import load_dotenv
 _env_path = os.path.join(os.path.dirname(__file__), ".env")
 load_dotenv(_env_path)
 
+from env_config import get_api_key, get_proxima_host, get_response_api_endpoint
+
 logger = logging.getLogger(__name__)
 
-# API Configuration (from env)
-API_KEY = os.getenv("PEBBLO_API_KEY", "")
-API_BASE_URL = os.getenv("PROXIMA_HOST", "http://localhost")
+# Operator-identity constants — frozen at load time from default .env.
+# These describe who is running the app (not which target environment),
+# so process-global values are acceptable here.
 USER_EMAIL = os.getenv("USER_EMAIL", "User")
 USER_TEAM = os.getenv("USER_TEAM", "Finance Ops")
-RESPONSE_API_ENDPOINT = f"{API_BASE_URL}/safe_infer/llm/v1/"
 X_PEBBLO_USER = os.getenv("X_PEBBLO_USER", None)
 X_PEBBLO_USER_GROUPS = os.getenv("X_PEBBLO_USER_GROUPS", None)
-MODEL = os.getenv("MODEL", "").strip()
-PEBBLO_USERS_LIST = [u.strip() for u in os.getenv("PEBBLO_USERS", "").split(",") if u.strip()]
 
 
 def _parse_user_groups_map(raw: str) -> dict:
@@ -50,7 +49,6 @@ def _parse_user_groups_map(raw: str) -> dict:
     return result
 
 
-PEBBLO_USER_GROUPS_MAP: dict = _parse_user_groups_map(os.getenv("PEBBLO_USER_GROUPS_MAP", ""))
 
 CUSTOM_CSS = """
 <style>
@@ -154,7 +152,7 @@ def _normalize_prompt_list(prompts: Any) -> List[Dict[str, str]]:
 
 def test_api_connection(api_base_url: str = None) -> Dict[str, Any]:
     """Test the API connection."""
-    base = api_base_url or API_BASE_URL
+    base = api_base_url or get_proxima_host()
     try:
         response = requests.get(f"{base}/safe_infer/healthz", timeout=5)
         if response.status_code == 200:
@@ -267,7 +265,7 @@ def _models_request_headers(
     pebblo_user: str = None,
     pebblo_user_groups: str = None,
 ) -> Dict[str, str]:
-    key = api_key if api_key is not None else API_KEY
+    key = api_key if api_key is not None else get_api_key()
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {key}" if key else "",
@@ -304,7 +302,7 @@ def get_available_models(
     On total failure returns ([], "").
     pebblo_user / pebblo_user_groups: optional overrides for Pebblo headers.
     """
-    base = (api_base_url or API_BASE_URL or "").rstrip("/")
+    base = (api_base_url or get_proxima_host() or "").rstrip("/")
     headers = _models_request_headers(api_key, pebblo_user, pebblo_user_groups)
 
     safe_infer_url = f"{base}/safe_infer/llm/v1/models"
@@ -353,7 +351,7 @@ def get_llm_client(
     pebblo_user: if non-empty, use for X-PEBBLO-USER header; else use env X_PEBBLO_USER.
     pebblo_user_groups: if non-empty, use for X-PEBBLO-USER-GROUPS; else use env.
     """
-    key = api_key or API_KEY
+    key = api_key or get_api_key()
     default_headers = {}
     header_user = (
         pebblo_user.strip() if (pebblo_user and pebblo_user.strip()) else X_PEBBLO_USER
@@ -369,7 +367,7 @@ def get_llm_client(
         default_headers["X-PEBBLO-USER-GROUPS"] = header_groups
     default_headers = default_headers or None
     return OpenAI(
-        base_url=RESPONSE_API_ENDPOINT,
+        base_url=get_response_api_endpoint(),
         api_key=key,
         default_headers=default_headers,
         http_client=_http_client(),


### PR DESCRIPTION
## Summary

- **New `env_config.py`** — replaces the JSON-override `settings_store.py`. Reads `?env=<name>` from the browser URL, resolves the matching `.env` file via `envs.json`, and loads it with `dotenv_values()` (never `load_dotenv`). Because `dotenv_values()` returns a plain dict without touching `os.environ`, multiple concurrent Streamlit sessions can target different environments without interfering with each other.
- **New `envs.json`** — maps env names to `.env` file paths. Add a new environment by creating `.env.<name>` and registering it here; no restart needed.
- **`deck_builder.py`** — all env-specific config (API key, model, users list, groups map, debug flag) now read dynamically from `env_config`; session state resets automatically when `?env=` changes; `fetch_models()` cache keyed per env.
- **`utils.py`** — removed frozen module-level `API_KEY`, `MODEL`, `PEBBLO_USERS_LIST` constants; replaced with dynamic calls.
- **`.gitignore`** — added `**/.env.*` and `**/.env-*` to cover all per-env secret files.
- **`.env.example`** — added `ENV_NAME` var and documents the `envs.json` workflow.

## Usage

```
# envs.json
{
  "hpe-demo-1": ".env.hpe-demo-1",
  "hpe-demo-2": ".env.hpe-demo-2"
}
```

- Default env (no param): `http://localhost:8501`
- Env 1: `http://localhost:8501?env=hpe-demo-1`
- Env 2: `http://localhost:8501?env=hpe-demo-2`

The sidebar shows the active env name. Switching the URL param instantly reloads the correct API key, gateway host, user list, and groups map for that session — no restart, no conflicts with other sessions.

## Test plan

- [ ] App starts without errors
- [ ] Default URL loads correctly using `.env`
- [ ] `?env=hpe-demo-2` loads `.env.hpe-demo-2` — sidebar shows correct host and env name
- [ ] Two browser tabs on different `?env=` values work simultaneously without interfering
- [ ] Adding a new entry to `envs.json` + new `.env` file takes effect immediately (no restart)
- [ ] `.env.*` and `.env-*` files are gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)